### PR TITLE
Clear interval and timeout when component unmounts

### DIFF
--- a/src/Konami.jsx
+++ b/src/Konami.jsx
@@ -7,6 +7,7 @@ class Konami extends React.Component {
     this.state = {
       done: false,
       input: [],
+      timeoutObj: null
     }
   }
 
@@ -15,6 +16,13 @@ class Konami extends React.Component {
     const delay = Number(this.props.resetDelay)
     if (delay !== 0) {
       this._timer = new this.Timer(() => this.resetInput(), delay)
+    }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.state.timeoutObj)
+    if (this.props.resetDelay !== 0) {
+      this._timer.stop()
     }
   }
 
@@ -44,10 +52,12 @@ class Konami extends React.Component {
         })
 
         if (timeout) {
-          setTimeout(() => {
-            this.setState({ done: false })
-            onTimeout && onTimeout()
-          }, Number(timeout))
+          this.setState({
+            done: false,
+            timeoutObj: setTimeout(() => {
+              onTimeout && onTimeout()
+            }, Number(timeout))
+          })
         }
       }
     })    

--- a/src/Konami.jsx
+++ b/src/Konami.jsx
@@ -1,13 +1,14 @@
 const React = require('react')
 
 class Konami extends React.Component {
+  timeoutId = 0;
+
   constructor(props) {
     super(props)
 
     this.state = {
       done: false,
       input: [],
-      timeoutObj: null
     }
   }
 
@@ -20,7 +21,7 @@ class Konami extends React.Component {
   }
 
   componentWillUnmount() {
-    clearTimeout(this.state.timeoutObj)
+    clearTimeout(this.timeoutId)
     if (this.props.resetDelay !== 0) {
       this._timer.stop()
     }
@@ -52,12 +53,10 @@ class Konami extends React.Component {
         })
 
         if (timeout) {
-          this.setState({
-            timeoutObj: setTimeout(() => {
-              this.setState({ done: false })
-              onTimeout && onTimeout()
-            }, Number(timeout))
-          })
+          this.timeoutId = setTimeout(() => {
+            this.setState({ done: false })
+            onTimeout && onTimeout()
+          }, Number(timeout))
         }
       }
     })    

--- a/src/Konami.jsx
+++ b/src/Konami.jsx
@@ -53,8 +53,8 @@ class Konami extends React.Component {
 
         if (timeout) {
           this.setState({
-            done: false,
             timeoutObj: setTimeout(() => {
+              this.setState({ done: false })
               onTimeout && onTimeout()
             }, Number(timeout))
           })


### PR DESCRIPTION
Clear the props.timeout and resetDelay interval when component unmounts to prevent the following React error:
`Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.`
https://reactjs.org/docs/react-component.html#componentwillunmount