### PR TITLE
Remove keyup event on componentWillUnmount()

### DIFF
--- a/src/Konami.jsx
+++ b/src/Konami.jsx
@@ -29,6 +29,7 @@ class Konami extends React.Component {
     if (resetDelay !== 0) {
       this._timer.stop();
     }
+    document.removeEventListener('keyup', this.onKeyUp);
   }
 
   onKeyUp = (e) => {


### PR DESCRIPTION
Remove keyup event on componentWillUnmount() to avoid a memory leak.