### PR TITLE
TS: Add missing `onTimeout` definition.

### DIFF
--- a/src/Konami.d.ts
+++ b/src/Konami.d.ts
@@ -7,6 +7,7 @@ export interface KonamiProps {
   resetDelay?: number;
   action?: () => void;
   timeout?: number;
+  onTimeout?: () => void;
 }
 
 export interface KonamiStates {


### PR DESCRIPTION
The `onTimeout` function is missing on the TypeScript defintion for the component properties.