### PR TITLE
Fixes type declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.2.1",
   "description": "Trigger an easter egg by pressing a sequence of keys. Available as a component or a custom hook. Supports timeout and input debounce/reset.",
   "main": "dist/Konami.js",
-  "types": "dist/Konami.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prebuild": "rm -rf ./dist",
     "build": "webpack --mode production",


### PR DESCRIPTION
This PR fixes type declaration inside package.json. `Konami.d.ts` don't include the hook `useKonami` type, causing the following error:

![image](https://user-images.githubusercontent.com/13911440/116706213-c4b6a680-a9a3-11eb-8084-a148dea5eb75.png)
